### PR TITLE
constants should be scoped inside the class

### DIFF
--- a/lib/mersenne.js
+++ b/lib/mersenne.js
@@ -52,6 +52,8 @@
 
 function MersenneTwister19937()
 {
+	/* constants should be scoped inside the class */
+	var N, M, MATRIX_A, UPPER_MASK, LOWER_MASK;
 	/* Period parameters */
 	//c//#define N 624
 	//c//#define M 397


### PR DESCRIPTION
``` js
var M = require('mersenne').MersenneTwister19937;
var i = 2;
while (i--) {
  new M();
}
```

this fails because there is no scope for the static M inside the class, so I added declarations.
